### PR TITLE
CHORE/COM-243_Docusaurus_3.5.2_update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@amsterdam/design-system-css": "^0.7.1",
         "@amsterdam/design-system-react": "^0.7.1",
         "@amsterdam/design-system-tokens": "^0.7.1",
-        "@docusaurus/core": "^3.4.0",
-        "@docusaurus/preset-classic": "^3.4.0",
+        "@docusaurus/core": "^3.5.2",
+        "@docusaurus/preset-classic": "^3.5.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "ee-docs-importer": "github:amsterdam/ee-docs-importer#v0.0.2",
@@ -24,9 +24,9 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.4.0",
-        "@docusaurus/tsconfig": "^3.4.0",
-        "@docusaurus/types": "^3.4.0",
+        "@docusaurus/module-type-aliases": "^3.5.2",
+        "@docusaurus/tsconfig": "^3.5.2",
+        "@docusaurus/types": "^3.5.2",
         "@eslint/eslintrc": "^3.0.2",
         "@eslint/js": "^9.0.0",
         "@types/eslint__js": "^8.42.3",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "@amsterdam/design-system-css": "^0.7.1",
     "@amsterdam/design-system-react": "^0.7.1",
     "@amsterdam/design-system-tokens": "^0.7.1",
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/preset-classic": "^3.4.0",
+    "@docusaurus/core": "^3.5.2",
+    "@docusaurus/preset-classic": "^3.5.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "ee-docs-importer": "github:amsterdam/ee-docs-importer#v0.0.2",
@@ -34,9 +34,9 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/tsconfig": "^3.4.0",
-    "@docusaurus/types": "^3.4.0",
+    "@docusaurus/module-type-aliases": "^3.5.2",
+    "@docusaurus/tsconfig": "^3.5.2",
+    "@docusaurus/types": "^3.5.2",
     "@eslint/eslintrc": "^3.0.2",
     "@eslint/js": "^9.0.0",
     "@types/eslint__js": "^8.42.3",


### PR DESCRIPTION
Update to docusaurus 3.5.2

- No updates in code only packages since new features were focused on blogs and we don't have that.