### PR TITLE
BUGFIX/COM-268_update_sidebar 

### DIFF
--- a/docs/projects/sso.md
+++ b/docs/projects/sso.md
@@ -1,4 +1,4 @@
-# Project Standard for Single Sign-On (SSO)
+# Single Sign-On (SSO)
 
 This project provides a standard for implementing Single Sign-On (SSO) within our organization. The documentation outlines guidelines and best practices for securely and efficiently integrating SSO into internal applications. By using SSO, users can access multiple systems with a single set of credentials, improving both user experience and security while simplifying management.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -6,7 +6,9 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  - render a sidebar for each doc of that group
  - provide next/previous navigation
 
- The sidebars can be generated from the filesystem, or explicitly defined here.
+ The sidebars can be generated from the filesystem, or explicitly defined here. Please be advised,
+ when adding new docs to a group in the sidebar, a hash collision might happen in the routing to that
+ doc (in route.js). Changing the new name of the new file should solve this.
 
  Create as many sidebars as you want.
  */
@@ -41,7 +43,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Projects',
-      items: ['projects/maps'],
+      items: ['projects/maps', 'projects/sso'],
     },
   ],
   // By default, Docusaurus generates a sidebar from the docs folder structure


### PR DESCRIPTION
Fix error in routing to new doc in sidebar.

There is a bug in Docusaurus. Only 3 letters are used for hashing the routes/paths. A hash collision can occur when adding a new doc to a group of docs in sidebars.tsx. See route.js A workaround is adding the new file and then changing the name of said file. SSO file was added to the projects group in Sidebars.tsx.