### PR TITLE
robots.txt file added to verify domain for search indexing

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,1 @@
+# Algolia-Crawler-Verif: 1D8CB27FB465062A


### PR DESCRIPTION
Verify the developers.amsterdam domain so that algolia crawler will start to index things