### PR TITLE
remove unused language locale

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -26,7 +26,7 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'nl'],
+    locales: ['en'],
   },
 
   presets: [


### PR DESCRIPTION
Remove the unused NL language locale, as we don't have any Dutch pages and this config option creates misleading URLs, for example:
https://developers.amsterdam/docs/intro/

is also available via
https://developers.amsterdam/nl/docs/intro/ but there is no translated version