### PR TITLE
Fix for breadcrumb separator icon in dark mode

### DIFF
--- a/src/css/ams-overrides.css
+++ b/src/css/ams-overrides.css
@@ -43,3 +43,7 @@
 [data-theme='dark'] .ams-page-menu__link:hover {
   color: var(--ifm-link-color);
 }
+
+[data-theme='dark'] .ams-breadcrumb__item:not(:last-child):after {
+  filter: invert(1);
+}


### PR DESCRIPTION
The breadcrumb separator is the same color as the page background in dark mode, this fixes it by inverting the icon.