### PR TITLE
Feature/com 226 intro mobile full width

### DIFF
--- a/src/components/HomepageCallToAction/index.tsx
+++ b/src/components/HomepageCallToAction/index.tsx
@@ -1,41 +1,37 @@
 import React from 'react';
-import { Grid, Heading, Image, Link, Overlap, Paragraph } from '@amsterdam/design-system-react';
+import { Grid, Heading, Image, Link, Paragraph } from '@amsterdam/design-system-react';
 import styles from './styles.module.css';
 
 const HomepageCallToAction = () => {
   return (
-    <Grid.Cell span="all">
-      <Overlap>
-        <Grid className="ams-grid_inner">
-          <Grid.Cell span={7}>
-            <Heading className="ams-mb--sm" size="level-2">
-              Contribute
-            </Heading>
-            <Paragraph>
-              Developers.amsterdam offers an overview of the standards and shared components
-              maintained by the municipality of Amsterdam. Contributions to enhance the platform are
-              encouraged, with resources available to learn how to get involved.
-            </Paragraph>
-            <br />
-            <Link href="/docs/intro" className="intro-link" onBackground="dark">
-              Share your input
-            </Link>
-          </Grid.Cell>
-          <Grid.Cell span={5}>
-            <Image
-              sizes="(max-width: 480px) 100vw,
-              (max-width: 800px) 50vw,
-              33vw"
-              srcSet="img/aanzicht_Amsterdam_480w.png 480w, img/aanzicht_Amsterdam_800w.png 800w, img/aanzicht_Amsterdam_1200w.png 1200w"
-              loading="lazy"
-              src="img/aanzicht_Amsterdam.png"
-              className={styles.image}
-              alt=""
-            />
-          </Grid.Cell>
-        </Grid>
-      </Overlap>
-    </Grid.Cell>
+    <Grid paddingTop="medium">
+      <Grid.Cell span={{ narrow: 12, medium: 12, wide: 7 }}>
+        <Heading className="ams-mb--sm" size="level-2">
+          Contribute
+        </Heading>
+        <Paragraph>
+          Developers.amsterdam offers an overview of the standards and shared components maintained
+          by the municipality of Amsterdam. Contributions to enhance the platform are encouraged,
+          with resources available to learn how to get involved.
+        </Paragraph>
+        <br />
+        <Link href="/docs/intro" className="intro-link" onBackground="dark">
+          Share your input
+        </Link>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 12, medium: 12, wide: 5 }}>
+        <Image
+          sizes="(max-width: 480px) 100vw,
+          (max-width: 800px) 50vw,
+          33vw"
+          srcSet="img/aanzicht_Amsterdam_480w.png 480w, img/aanzicht_Amsterdam_800w.png 800w, img/aanzicht_Amsterdam_1200w.png 1200w"
+          loading="lazy"
+          src="img/aanzicht_Amsterdam.png"
+          className={styles.image}
+          alt=""
+        />
+      </Grid.Cell>
+    </Grid>
   );
 };
 

--- a/src/components/HomepageCallToAction/index.tsx
+++ b/src/components/HomepageCallToAction/index.tsx
@@ -4,7 +4,7 @@ import styles from './styles.module.css';
 
 const HomepageCallToAction = () => {
   return (
-    <Grid paddingTop="medium">
+    <Grid paddingTop="medium" paddingBottom="medium">
       <Grid.Cell span={{ narrow: 12, medium: 12, wide: 7 }}>
         <Heading className="ams-mb--sm" size="level-2">
           Contribute

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -82,7 +82,7 @@ const featureList: FeatureItem[] = [
 
 export default function HomepageFeatures(): JSX.Element {
   return (
-    <>
+    <Grid paddingBottom="large">
       <Grid.Cell span="all">
         <Heading className="ams-mb--sm" size="level-3">
           Guidelines
@@ -106,6 +106,6 @@ export default function HomepageFeatures(): JSX.Element {
           </Card>
         </Grid.Cell>
       ))}
-    </>
+    </Grid>
   );
 }

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -37,46 +37,46 @@ const featureList: FeatureItem[] = [
     image: SourceControlIcon,
     title: 'Storing source code',
     to: '/docs/general/storing-source-code',
-    description: 'We use Git to store our source code. ',
+    description: 'We use Git to store our source code.',
   },
   {
     image: TestingIcon,
     title: 'Testing',
     to: '/docs/general/testing',
-    description: 'A summation of libraries used by the developers of the city of Amsterdam',
+    description: 'What to test and how.',
   },
   {
     image: GitHubIcon,
     title: 'Using Git',
     to: '/docs/general/using-git',
-    description: 'Our policy how to use Git',
+    description: 'Our policy how to use Git.',
   },
   {
     image: ThirdPartyIcon,
     title: 'Third party dependencies in general',
     to: '/docs/general/third-party-dependencies',
-    description: 'A guideline on how to choose',
+    description: 'A guideline on how to choose third party frameworks and libraries.',
   },
   {
     image: ThirdPartyIcon,
     title: 'Frontend - Third party dependencies',
     to: '/docs/frontend/third-party-dependencies',
-    description:
-      ' A list of recommended packages and set guidelines for choosing a package which is not on the list.',
+    description: 'A list of recommended packages and set of guidelines for choosing a new package.',
   },
   {
     image: ReactIcon,
     title: 'Frontend - Languages and Frameworks (Not yet formatted to meet the required standard.)',
     to: '/docs/frontend/languages-and-frameworks',
     description:
-      'For all frontend projects within de Municipality of Amsterdam we choose to work with React and its ecosystem.',
+      'For frontend applications within the municipality of Amsterdam we choose to work with React and its ecosystem.',
   },
   {
     image: SharedIcon,
-    title: 'Frontend - Shared components (Not yet formatted to meet the required standard.)',
+    title:
+      'Frontend - Shared components and demos (Not yet formatted to meet the required standard.)',
     to: '/docs/frontend/shared-components',
     description:
-      'A list of components that our being used by the developers of the city of Amsterdam',
+      'A list of internal components and demos that are used by the developers of the city of Amsterdam.',
   },
 ];
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React, { type FunctionComponent } from 'react';
 import clsx from 'clsx';
-import { Grid, Screen } from '@amsterdam/design-system-react';
+import { Screen } from '@amsterdam/design-system-react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import HomepageCallToAction from '@site/src/components/HomepageCallToAction';
@@ -33,10 +33,8 @@ const Home: FunctionComponent = () => (
     <HomepageHeader />
     <main className={styles.container}>
       <Screen maxWidth="wide">
-        {/* <Grid paddingTop="medium" paddingBottom="large"> */}
-          <HomepageCallToAction />
-          <HomepageFeatures />
-        {/* </Grid> */}
+        <HomepageCallToAction />
+        <HomepageFeatures />
       </Screen>
     </main>
   </PlainLayout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,10 +33,10 @@ const Home: FunctionComponent = () => (
     <HomepageHeader />
     <main className={styles.container}>
       <Screen maxWidth="wide">
-        <Grid paddingTop="medium" paddingBottom="large">
+        {/* <Grid paddingTop="medium" paddingBottom="large"> */}
           <HomepageCallToAction />
           <HomepageFeatures />
-        </Grid>
+        {/* </Grid> */}
       </Screen>
     </main>
   </PlainLayout>


### PR DESCRIPTION
This moves the grid system container into each child component instead of having 1 global grid container. I'm not entirely sure why but this, along with some minor responsive `span` changes, fixes the intro block not taking 100% width on mobile (when the image is hidden).

I also threw in some english language cleanups.