### PR TITLE
Fix for footer link list markup and hover style

### DIFF
--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -28,27 +28,35 @@ const Footer: FC | null = () => {
     const navItems = (column.items as FooterLinkItem[]).map((item) => {
       if (item.to) {
         return (
+          <li key={uuidv4()}>
+            <Link
+              to={item.to}
+              className="ams-link-list__link ams-link-list__link--inverse-color ams-link-list__link--small"
+            >
+              <Icon svg={ChevronRightIcon} size="level-6" />
+              {item.label}
+            </Link>
+          </li>
+        );
+      }
+      return (
+        <li key={uuidv4()}>
           <Link
-            to={item.to}
-            className="ams-link-list__link ams-link-list__link--on-background-dark ams-link-list__link--small"
-            key={uuidv4()}
+            href={item.href}
+            target="_blank"
+            className="ams-link-list__link ams-link-list__link--inverse-color ams-link-list__link--small"
           >
             <Icon svg={ChevronRightIcon} size="level-6" />
             {item.label}
           </Link>
-        );
-      }
-      return (
-        <LinkList.Link href={item.href} target="_blank" inverseColor size="small" key={uuidv4()}>
-          {item.label}
-        </LinkList.Link>
+        </li>
       );
     });
 
     return (
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 7 }} key={uuidv4()}>
         <div className={styles.col}>
-          <Heading inverseColor level={2} size="level-4">
+          <Heading inverseColor level={2} size="level-4" className="ams-mb--xs">
             {column.title}
           </Heading>
           <LinkList>{navItems}</LinkList>

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -68,9 +68,9 @@ const Footer: FC | null = () => {
   return (
     <AmsFooter>
       <AmsFooter.Top>
-        <Paragraph className="ams-visually-hidden">
-          <Heading>Colofon</Heading>
-        </Paragraph>
+        <Heading className="ams-visually-hidden" inverseColor>
+          Colofon
+        </Heading>
         <Grid gapVertical="large" paddingVertical="medium" className={styles.grid}>
           {columns}
           <Grid.Cell span={{ narrow: 4, medium: 8, wide: 5 }}>

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -17,6 +17,10 @@
   color: #fff;
 }
 
+.col a:hover {
+  color: #fff;
+}
+
 [data-theme='dark'] .col a {
   color: var(--ifm-link-color);
 }

--- a/src/theme/Navbar/MobileSidebar/Header/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Header/index.tsx
@@ -14,7 +14,8 @@ export default function NavbarMobileSidebarHeader(): JSX.Element {
       <NavbarLogo />
       <IconButton
         label="Sluiten"
-        onBackground={colorMode === 'light' ? 'light' : 'dark'}
+        contrastColor={colorMode === 'dark'}
+        inverseColor={colorMode === 'dark'}
         aria-label={translate({
           id: 'theme.docs.sidebar.closeSidebarButtonAriaLabel',
           message: 'Close navigation bar',


### PR DESCRIPTION
On light mode - the footer links have different hover styling (because one is an external link and the other internal router link). This fixes that.