### PR TITLE
Replace home cards anchor with router link to prevent page reload on click

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -10,6 +10,7 @@ import SourceControlIcon from '@site/static/img/source-control.svg';
 import TestingIcon from '@site/static/img/testing.svg';
 import ThirdPartyIcon from '@site/static/img/third_party.svg';
 import W3CIcon from '@site/static/img/W3C.svg';
+import Link from '@docusaurus/Link';
 
 interface FeatureItem {
   title: string;
@@ -100,7 +101,9 @@ export default function HomepageFeatures(): JSX.Element {
                   listItem.title === 'Using Git' ? 'dark-mode-github-icon' : 'ams-card__image',
               })}
             <Heading size="level-4">
-              <Card.Link href={listItem.to}>{listItem.title}</Card.Link>
+              <Link to={listItem.to} className="ams-card__link">
+                {listItem.title}
+              </Link>
             </Heading>
             <Paragraph size="small">{listItem.description}</Paragraph>
           </Card>


### PR DESCRIPTION
On the new homepage design, if you click on one of the cards - as it uses an anchor element (via `Card.Link`) - it reloads the page. This makes use of the internal docusaurus router to prevent reloading the page.

Note for future - if any of these homepage cards becomes an external application link, then it should use the `Card.Link` component.