### PR TITLE
Bugfix/color of button Share your input in dark mode corrected

### DIFF
--- a/src/css/ams-overrides.css
+++ b/src/css/ams-overrides.css
@@ -70,13 +70,15 @@
   filter: invert(1) brightness(1.2);
 }
 
-[data-theme='dark'] .intro-link {
+[data-theme='dark'] .ams-button--primary {
   background-color: #FFFFFF;
+  box-shadow: none;
   text-decoration: none !important;
   color: #000000 !important;;
   padding: 8px 16px;
 }
 
-[data-theme='dark'] .intro-link:hover {
-  background-color: #E8E8E8;
+[data-theme='dark'] .ams-button--primary:hover {
+  background-color: #E8E8E8 !important;
+  box-shadow: none !important; 
 }


### PR DESCRIPTION
Fix color of button Share you input in dark mode and on dark mode:hover. Problem was caused by changing of classname. 